### PR TITLE
사용자 정보 API 추가

### DIFF
--- a/src/main/java/aladdinsys/lifelong_learning_survey/SurveyApplication.java
+++ b/src/main/java/aladdinsys/lifelong_learning_survey/SurveyApplication.java
@@ -1,12 +1,35 @@
 /* (C) 2024 AladdinSystem License */
 package aladdinsys.lifelong_learning_survey;
 
+import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+
+import aladdinsys.lifelong_learning_survey.domains.auth.dto.SignUpRequestDto;
+import aladdinsys.lifelong_learning_survey.domains.auth.service.AuthenticationService;
 
 @SpringBootApplication
 public class SurveyApplication {
   public static void main(String[] args) {
     SpringApplication.run(SurveyApplication.class, args);
+  }
+
+  @Bean
+  public CommandLineRunner runner(
+      AuthenticationService service
+
+  ) {
+    return args -> {
+      SignUpRequestDto dto = SignUpRequestDto.builder()
+          .userId("admin")
+          .password("user00!")
+          .name("관리자")
+          .code("0000")
+          .email("nadk@aladdinsys.co.kr")
+          .build();
+
+        service.signUpAdmin(dto);
+    };
   }
 }

--- a/src/main/java/aladdinsys/lifelong_learning_survey/SurveyApplication.java
+++ b/src/main/java/aladdinsys/lifelong_learning_survey/SurveyApplication.java
@@ -1,13 +1,12 @@
 /* (C) 2024 AladdinSystem License */
 package aladdinsys.lifelong_learning_survey;
 
+import aladdinsys.lifelong_learning_survey.domains.auth.dto.SignUpRequestDto;
+import aladdinsys.lifelong_learning_survey.domains.auth.service.AuthenticationService;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
-
-import aladdinsys.lifelong_learning_survey.domains.auth.dto.SignUpRequestDto;
-import aladdinsys.lifelong_learning_survey.domains.auth.service.AuthenticationService;
 
 @SpringBootApplication
 public class SurveyApplication {
@@ -16,20 +15,19 @@ public class SurveyApplication {
   }
 
   @Bean
-  public CommandLineRunner runner(
-      AuthenticationService service
+  public CommandLineRunner runner(AuthenticationService service) {
 
-  ) {
     return args -> {
-      SignUpRequestDto dto = SignUpRequestDto.builder()
-          .userId("admin")
-          .password("user00!")
-          .name("관리자")
-          .code("0000")
-          .email("nadk@aladdinsys.co.kr")
-          .build();
+      SignUpRequestDto dto =
+          SignUpRequestDto.builder()
+              .userId("admin")
+              .password("user00!")
+              .name("관리자")
+              .code("0000")
+              .email("nadk@aladdinsys.co.kr")
+              .build();
 
-        service.signUpAdmin(dto);
+      service.signUpAdmin(dto);
     };
   }
 }

--- a/src/main/java/aladdinsys/lifelong_learning_survey/domains/auth/controller/AuthenticationController.java
+++ b/src/main/java/aladdinsys/lifelong_learning_survey/domains/auth/controller/AuthenticationController.java
@@ -11,8 +11,6 @@ import aladdinsys.lifelong_learning_survey.domains.auth.service.AuthenticationSe
 import aladdinsys.lifelong_learning_survey.global.response.DataResponseBody;
 import aladdinsys.lifelong_learning_survey.global.response.ResponseBody;
 import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
-import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -39,8 +37,7 @@ public class AuthenticationController {
   }
 
   @PostMapping(value = "/refresh-token")
-  public DataResponseBody<RefreshTokenDto> refreshToken(
-      HttpServletRequest request, HttpServletResponse response) throws IOException {
-    return DataResponseBody.of(authenticationService.refreshToken(request, response));
+  public DataResponseBody<RefreshTokenDto> refreshToken(HttpServletRequest request) {
+    return DataResponseBody.of(authenticationService.refreshToken(request));
   }
 }

--- a/src/main/java/aladdinsys/lifelong_learning_survey/domains/auth/dto/SignUpRequestDto.java
+++ b/src/main/java/aladdinsys/lifelong_learning_survey/domains/auth/dto/SignUpRequestDto.java
@@ -4,7 +4,9 @@ package aladdinsys.lifelong_learning_survey.domains.auth.dto;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+import lombok.Builder;
 
+@Builder
 public record SignUpRequestDto(
     @NotNull(message = "사용자 ID는 필수 입니다.")
         @NotBlank(message = "사용자 ID는 공백이 될 수 없습니다.")

--- a/src/main/java/aladdinsys/lifelong_learning_survey/domains/auth/service/AuthenticationService.java
+++ b/src/main/java/aladdinsys/lifelong_learning_survey/domains/auth/service/AuthenticationService.java
@@ -7,6 +7,7 @@ import aladdinsys.lifelong_learning_survey.domains.auth.dto.RefreshTokenDto;
 import aladdinsys.lifelong_learning_survey.domains.auth.dto.SignInRequestDto;
 import aladdinsys.lifelong_learning_survey.domains.auth.dto.SignInResponseDto;
 import aladdinsys.lifelong_learning_survey.domains.auth.dto.SignUpRequestDto;
+import aladdinsys.lifelong_learning_survey.domains.user.constant.Role;
 import aladdinsys.lifelong_learning_survey.domains.user.entity.User;
 import aladdinsys.lifelong_learning_survey.domains.user.repository.UserRepository;
 import aladdinsys.lifelong_learning_survey.global.exception.CustomException;
@@ -37,6 +38,19 @@ public class AuthenticationService {
 
   private final AuthenticationManager authenticationManager;
 
+  @Transactional
+  public void signUpAdmin(final SignUpRequestDto signUpRequestDto) {
+    var user = User.builder()
+            .userId(signUpRequestDto.userId())
+            .password(passwordEncoder.encode(signUpRequestDto.password()))
+            .name(signUpRequestDto.name())
+            .code(signUpRequestDto.code())
+            .email(signUpRequestDto.email())
+            .role(Role.ADMIN)
+            .build();
+
+    userRepository.save(user);
+  }
   @Transactional
   public void signUp(final SignUpRequestDto signUpRequestDto) {
 

--- a/src/main/java/aladdinsys/lifelong_learning_survey/domains/auth/service/AuthenticationService.java
+++ b/src/main/java/aladdinsys/lifelong_learning_survey/domains/auth/service/AuthenticationService.java
@@ -14,8 +14,6 @@ import aladdinsys.lifelong_learning_survey.global.exception.CustomException;
 import aladdinsys.lifelong_learning_survey.global.security.CustomUserDetails;
 import aladdinsys.lifelong_learning_survey.global.security.JwtProvider;
 import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
-import java.io.IOException;
 import java.util.regex.Pattern;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -40,7 +38,8 @@ public class AuthenticationService {
 
   @Transactional
   public void signUpAdmin(final SignUpRequestDto signUpRequestDto) {
-    var user = User.builder()
+    var user =
+        User.builder()
             .userId(signUpRequestDto.userId())
             .password(passwordEncoder.encode(signUpRequestDto.password()))
             .name(signUpRequestDto.name())
@@ -51,6 +50,7 @@ public class AuthenticationService {
 
     userRepository.save(user);
   }
+
   @Transactional
   public void signUp(final SignUpRequestDto signUpRequestDto) {
 
@@ -120,8 +120,7 @@ public class AuthenticationService {
         .build();
   }
 
-  public RefreshTokenDto refreshToken(HttpServletRequest request, HttpServletResponse response)
-      throws IOException {
+  public RefreshTokenDto refreshToken(HttpServletRequest request) {
 
     String refreshToken = jwtProvider.getJwtFromRequest(request);
 

--- a/src/main/java/aladdinsys/lifelong_learning_survey/domains/user/controller/UserController.java
+++ b/src/main/java/aladdinsys/lifelong_learning_survey/domains/user/controller/UserController.java
@@ -3,8 +3,14 @@ package aladdinsys.lifelong_learning_survey.domains.user.controller;
 
 import static aladdinsys.lifelong_learning_survey.global.constant.SuccessCode.*;
 
+import aladdinsys.lifelong_learning_survey.domains.user.dto.ChangePasswordDto;
+import aladdinsys.lifelong_learning_survey.domains.user.dto.PatchDto;
+import aladdinsys.lifelong_learning_survey.domains.user.dto.ResponseDto;
+import aladdinsys.lifelong_learning_survey.domains.user.service.UserService;
+import aladdinsys.lifelong_learning_survey.global.response.DataResponseBody;
+import aladdinsys.lifelong_learning_survey.global.response.ResponseBody;
 import java.util.List;
-
+import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -12,14 +18,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import aladdinsys.lifelong_learning_survey.domains.user.dto.ChangePasswordDto;
-import aladdinsys.lifelong_learning_survey.domains.user.dto.PatchDto;
-import aladdinsys.lifelong_learning_survey.domains.user.dto.ResponseDto;
-import aladdinsys.lifelong_learning_survey.domains.user.service.UserService;
-import aladdinsys.lifelong_learning_survey.global.response.DataResponseBody;
-import aladdinsys.lifelong_learning_survey.global.response.ResponseBody;
-import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequestMapping("/users")
@@ -34,36 +32,26 @@ public class UserController {
   }
 
   @GetMapping(value = "/{id}", produces = "application/json")
-  public DataResponseBody<ResponseDto> getUser(
-      @PathVariable("id") Long id
-  ) {
+  public DataResponseBody<ResponseDto> getUser(@PathVariable("id") Long id) {
     return DataResponseBody.of(service.findById(id));
   }
 
   @PatchMapping(value = "/{id}", produces = "application/json")
-  public ResponseBody patchUserInfo(
-      @PathVariable("id") Long id,
-      @RequestBody PatchDto dto
-  ) {
+  public ResponseBody patchUserInfo(@PathVariable("id") Long id, @RequestBody PatchDto dto) {
     service.patch(id, dto);
     return ResponseBody.of(SUCCESS_PATCH);
   }
 
   @PatchMapping(value = "/{id}/change-password", produces = "application/json")
   public ResponseBody changePassword(
-      @PathVariable("id") Long id,
-      @RequestBody ChangePasswordDto dto
-  ) {
+      @PathVariable("id") Long id, @RequestBody ChangePasswordDto dto) {
     service.changePassword(id, dto);
     return ResponseBody.of(SUCCESS_PATCH);
   }
 
   @DeleteMapping(value = "/{id}", produces = "application/json")
-  public ResponseBody deleteUser(
-      @PathVariable("id") Long id
-  ) {
+  public ResponseBody deleteUser(@PathVariable("id") Long id) {
     service.delete(id);
     return ResponseBody.of(SUCCESS_DELETE);
   }
-
 }

--- a/src/main/java/aladdinsys/lifelong_learning_survey/domains/user/controller/UserController.java
+++ b/src/main/java/aladdinsys/lifelong_learning_survey/domains/user/controller/UserController.java
@@ -1,15 +1,25 @@
 /* (C) 2024 AladdinSystem License */
 package aladdinsys.lifelong_learning_survey.domains.user.controller;
 
-import aladdinsys.lifelong_learning_survey.domains.user.dto.UserResponseDto;
-import aladdinsys.lifelong_learning_survey.domains.user.service.UserService;
-import aladdinsys.lifelong_learning_survey.global.response.DataResponseBody;
-import java.security.Principal;
+import static aladdinsys.lifelong_learning_survey.global.constant.SuccessCode.*;
+
 import java.util.List;
-import lombok.RequiredArgsConstructor;
+
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import aladdinsys.lifelong_learning_survey.domains.user.dto.ChangePasswordDto;
+import aladdinsys.lifelong_learning_survey.domains.user.dto.PatchDto;
+import aladdinsys.lifelong_learning_survey.domains.user.dto.ResponseDto;
+import aladdinsys.lifelong_learning_survey.domains.user.service.UserService;
+import aladdinsys.lifelong_learning_survey.global.response.DataResponseBody;
+import aladdinsys.lifelong_learning_survey.global.response.ResponseBody;
+import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequestMapping("/users")
@@ -19,12 +29,41 @@ public class UserController {
   private final UserService service;
 
   @GetMapping
-  public DataResponseBody<List<UserResponseDto>> getEmployees() {
+  public DataResponseBody<List<ResponseDto>> getUsers() {
     return DataResponseBody.of(service.findAll());
   }
 
-  @GetMapping(value = "/my-info", produces = "application/json")
-  public DataResponseBody<UserResponseDto> getMyInfo(Principal principal) {
-    return DataResponseBody.of(service.myInfo(principal));
+  @GetMapping(value = "/{id}", produces = "application/json")
+  public DataResponseBody<ResponseDto> getUser(
+      @PathVariable("id") Long id
+  ) {
+    return DataResponseBody.of(service.findById(id));
   }
+
+  @PatchMapping(value = "/{id}", produces = "application/json")
+  public ResponseBody patchUserInfo(
+      @PathVariable("id") Long id,
+      @RequestBody PatchDto dto
+  ) {
+    service.patch(id, dto);
+    return ResponseBody.of(SUCCESS_PATCH);
+  }
+
+  @PatchMapping(value = "/{id}", produces = "application/json")
+  public ResponseBody changePassword(
+      @PathVariable("id") Long id,
+      @RequestBody ChangePasswordDto dto
+  ) {
+    service.changePassword(id, dto);
+    return ResponseBody.of(SUCCESS_PATCH);
+  }
+
+  @DeleteMapping(value = "/{id}", produces = "application/json")
+  public ResponseBody deleteUser(
+      @PathVariable("id") Long id
+  ) {
+    service.delete(id);
+    return ResponseBody.of(SUCCESS_DELETE);
+  }
+
 }

--- a/src/main/java/aladdinsys/lifelong_learning_survey/domains/user/controller/UserController.java
+++ b/src/main/java/aladdinsys/lifelong_learning_survey/domains/user/controller/UserController.java
@@ -49,7 +49,7 @@ public class UserController {
     return ResponseBody.of(SUCCESS_PATCH);
   }
 
-  @PatchMapping(value = "/{id}", produces = "application/json")
+  @PatchMapping(value = "/{id}/change-password", produces = "application/json")
   public ResponseBody changePassword(
       @PathVariable("id") Long id,
       @RequestBody ChangePasswordDto dto

--- a/src/main/java/aladdinsys/lifelong_learning_survey/domains/user/controller/UserSelfController.java
+++ b/src/main/java/aladdinsys/lifelong_learning_survey/domains/user/controller/UserSelfController.java
@@ -1,23 +1,22 @@
+/* (C) 2024 AladdinSystem License */
 package aladdinsys.lifelong_learning_survey.domains.user.controller;
-
-import java.security.Principal;
-
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RestController;
 
 import aladdinsys.lifelong_learning_survey.domains.user.dto.ResponseDto;
 import aladdinsys.lifelong_learning_survey.domains.user.service.UserService;
 import aladdinsys.lifelong_learning_survey.global.response.DataResponseBody;
+import java.security.Principal;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
 public class UserSelfController {
 
-	private final UserService service;
+  private final UserService service;
 
-	@GetMapping(value = "/my-info", produces = "application/json")
-	public DataResponseBody<ResponseDto> getMyInfo(Principal principal) {
-		return DataResponseBody.of(service.myInfo(principal));
-	}
+  @GetMapping(value = "/my-info", produces = "application/json")
+  public DataResponseBody<ResponseDto> getMyInfo(Principal principal) {
+    return DataResponseBody.of(service.myInfo(principal));
+  }
 }

--- a/src/main/java/aladdinsys/lifelong_learning_survey/domains/user/controller/UserSelfController.java
+++ b/src/main/java/aladdinsys/lifelong_learning_survey/domains/user/controller/UserSelfController.java
@@ -1,0 +1,23 @@
+package aladdinsys.lifelong_learning_survey.domains.user.controller;
+
+import java.security.Principal;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import aladdinsys.lifelong_learning_survey.domains.user.dto.ResponseDto;
+import aladdinsys.lifelong_learning_survey.domains.user.service.UserService;
+import aladdinsys.lifelong_learning_survey.global.response.DataResponseBody;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+public class UserSelfController {
+
+	private final UserService service;
+
+	@GetMapping(value = "/my-info", produces = "application/json")
+	public DataResponseBody<ResponseDto> getMyInfo(Principal principal) {
+		return DataResponseBody.of(service.myInfo(principal));
+	}
+}

--- a/src/main/java/aladdinsys/lifelong_learning_survey/domains/user/dto/ChangePasswordDto.java
+++ b/src/main/java/aladdinsys/lifelong_learning_survey/domains/user/dto/ChangePasswordDto.java
@@ -1,7 +1,4 @@
+/* (C) 2024 AladdinSystem License */
 package aladdinsys.lifelong_learning_survey.domains.user.dto;
 
-public record ChangePasswordDto(
-	String password,
-	String newPassword
-) {
-}
+public record ChangePasswordDto(String password, String newPassword) {}

--- a/src/main/java/aladdinsys/lifelong_learning_survey/domains/user/dto/ChangePasswordDto.java
+++ b/src/main/java/aladdinsys/lifelong_learning_survey/domains/user/dto/ChangePasswordDto.java
@@ -1,0 +1,7 @@
+package aladdinsys.lifelong_learning_survey.domains.user.dto;
+
+public record ChangePasswordDto(
+	String password,
+	String newPassword
+) {
+}

--- a/src/main/java/aladdinsys/lifelong_learning_survey/domains/user/dto/PatchDto.java
+++ b/src/main/java/aladdinsys/lifelong_learning_survey/domains/user/dto/PatchDto.java
@@ -1,14 +1,10 @@
+/* (C) 2024 AladdinSystem License */
 package aladdinsys.lifelong_learning_survey.domains.user.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 public record PatchDto(
-	@NotNull(message = "이름은 필수 입니다.") @NotBlank(message = "이름은 공백이 될 수 없습니다.")
-	String name,
-	@NotNull(message = "E-mail은 필수 입니다.") @NotBlank(message = "E-mail은 공백이 될 수 없습니다.")
-	String email,
-	@NotNull(message = "부서 코드는 필수 입니다.") @NotBlank(message = "부서 코드는 공백이 될 수 없습니다.")
-	String code
-) {
-}
+    @NotNull(message = "이름은 필수 입니다.") @NotBlank(message = "이름은 공백이 될 수 없습니다.") String name,
+    @NotNull(message = "E-mail은 필수 입니다.") @NotBlank(message = "E-mail은 공백이 될 수 없습니다.") String email,
+    @NotNull(message = "부서 코드는 필수 입니다.") @NotBlank(message = "부서 코드는 공백이 될 수 없습니다.") String code) {}

--- a/src/main/java/aladdinsys/lifelong_learning_survey/domains/user/dto/PatchDto.java
+++ b/src/main/java/aladdinsys/lifelong_learning_survey/domains/user/dto/PatchDto.java
@@ -4,8 +4,6 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 public record PatchDto(
-	@NotNull(message = "사용자 ID는 필수 입니다.") @NotBlank(message = "사용자 ID는 공백이 될 수 없습니다.")
-	String userId,
 	@NotNull(message = "이름은 필수 입니다.") @NotBlank(message = "이름은 공백이 될 수 없습니다.")
 	String name,
 	@NotNull(message = "E-mail은 필수 입니다.") @NotBlank(message = "E-mail은 공백이 될 수 없습니다.")

--- a/src/main/java/aladdinsys/lifelong_learning_survey/domains/user/dto/PatchDto.java
+++ b/src/main/java/aladdinsys/lifelong_learning_survey/domains/user/dto/PatchDto.java
@@ -1,0 +1,16 @@
+package aladdinsys.lifelong_learning_survey.domains.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record PatchDto(
+	@NotNull(message = "사용자 ID는 필수 입니다.") @NotBlank(message = "사용자 ID는 공백이 될 수 없습니다.")
+	String userId,
+	@NotNull(message = "이름은 필수 입니다.") @NotBlank(message = "이름은 공백이 될 수 없습니다.")
+	String name,
+	@NotNull(message = "E-mail은 필수 입니다.") @NotBlank(message = "E-mail은 공백이 될 수 없습니다.")
+	String email,
+	@NotNull(message = "부서 코드는 필수 입니다.") @NotBlank(message = "부서 코드는 공백이 될 수 없습니다.")
+	String code
+) {
+}

--- a/src/main/java/aladdinsys/lifelong_learning_survey/domains/user/dto/ResponseDto.java
+++ b/src/main/java/aladdinsys/lifelong_learning_survey/domains/user/dto/ResponseDto.java
@@ -2,5 +2,7 @@
 package aladdinsys.lifelong_learning_survey.domains.user.dto;
 
 import aladdinsys.lifelong_learning_survey.domains.user.constant.Role;
+import lombok.Builder;
 
-public record UserResponseDto(String userId, String name, String email, String code, Role role) {}
+@Builder
+public record ResponseDto(String userId, String name, String email, String code, Role role) {}

--- a/src/main/java/aladdinsys/lifelong_learning_survey/domains/user/entity/User.java
+++ b/src/main/java/aladdinsys/lifelong_learning_survey/domains/user/entity/User.java
@@ -52,4 +52,14 @@ public class User {
   public void prePersist() {
     this.role = Role.USER;
   }
+
+  public void changePassword(final String newPassword) {
+    this.password = newPassword;
+  }
+
+  public void updateInfo(final String name, final String code, final String email) {
+    this.name = name;
+    this.code = code;
+    this.email = email;
+  }
 }

--- a/src/main/java/aladdinsys/lifelong_learning_survey/domains/user/entity/User.java
+++ b/src/main/java/aladdinsys/lifelong_learning_survey/domains/user/entity/User.java
@@ -46,12 +46,7 @@ public class User {
 
   @Column(name = "role")
   @Enumerated(EnumType.STRING)
-  private Role role;
-
-  @PrePersist
-  public void prePersist() {
-    this.role = Role.USER;
-  }
+  private Role role = Role.USER;
 
   public void changePassword(final String newPassword) {
     this.password = newPassword;

--- a/src/main/java/aladdinsys/lifelong_learning_survey/domains/user/entity/User.java
+++ b/src/main/java/aladdinsys/lifelong_learning_survey/domains/user/entity/User.java
@@ -9,7 +9,6 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;

--- a/src/main/java/aladdinsys/lifelong_learning_survey/domains/user/service/UserService.java
+++ b/src/main/java/aladdinsys/lifelong_learning_survey/domains/user/service/UserService.java
@@ -12,7 +12,6 @@ import aladdinsys.lifelong_learning_survey.global.exception.CustomException;
 import java.security.Principal;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;

--- a/src/main/java/aladdinsys/lifelong_learning_survey/domains/user/service/UserService.java
+++ b/src/main/java/aladdinsys/lifelong_learning_survey/domains/user/service/UserService.java
@@ -3,13 +3,17 @@ package aladdinsys.lifelong_learning_survey.domains.user.service;
 
 import static aladdinsys.lifelong_learning_survey.global.constant.ErrorCode.*;
 
-import aladdinsys.lifelong_learning_survey.domains.user.dto.UserResponseDto;
+import aladdinsys.lifelong_learning_survey.domains.user.dto.ChangePasswordDto;
+import aladdinsys.lifelong_learning_survey.domains.user.dto.PatchDto;
+import aladdinsys.lifelong_learning_survey.domains.user.dto.ResponseDto;
 import aladdinsys.lifelong_learning_survey.domains.user.entity.User;
 import aladdinsys.lifelong_learning_survey.domains.user.repository.UserRepository;
 import aladdinsys.lifelong_learning_survey.global.exception.CustomException;
 import java.security.Principal;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,14 +23,16 @@ public class UserService {
 
   private final UserRepository repository;
 
+  private final PasswordEncoder passwordEncoder;
+
   @Transactional(readOnly = true)
-  public List<UserResponseDto> findAll() {
+  public List<ResponseDto> findAll() {
     List<User> users = repository.findAll();
 
     return users.stream()
         .map(
             user ->
-                new UserResponseDto(
+                new ResponseDto(
                     user.getUserId(),
                     user.getName(),
                     user.getEmail(),
@@ -36,12 +42,42 @@ public class UserService {
   }
 
   @Transactional(readOnly = true)
-  public UserResponseDto myInfo(Principal principal) {
+  public ResponseDto findById(Long id) {
+    User user = repository.findById(id).orElseThrow(() -> new CustomException(NOT_FOUND_USER));
+
+    return ResponseDto.builder()
+        .userId(user.getUserId())
+        .name(user.getName())
+        .email(user.getEmail())
+        .code(user.getCode())
+        .role(user.getRole())
+        .build();
+  }
+
+  @Transactional
+  public void patch(Long id, PatchDto dto) {
+    User user = repository.findById(id).orElseThrow(() -> new CustomException(NOT_FOUND_USER));
+    user.updateInfo(dto.name(), dto.code(), dto.email());
+  }
+
+  @Transactional
+  public void changePassword(Long id, ChangePasswordDto dto) {
+    User user = repository.findById(id).orElseThrow(() -> new CustomException(NOT_FOUND_USER));
+    user.changePassword(passwordEncoder.encode(dto.newPassword()));
+  }
+
+  @Transactional
+  public void delete(Long id) {
+    repository.deleteById(id);
+  }
+
+  @Transactional(readOnly = true)
+  public ResponseDto myInfo(Principal principal) {
     var userId = principal.getName();
     User user =
         repository.findByUserId(userId).orElseThrow(() -> new CustomException(NOT_FOUND_USER));
 
-    return new UserResponseDto(
+    return new ResponseDto(
         user.getUserId(), user.getName(), user.getEmail(), user.getCode(), user.getRole());
   }
 }

--- a/src/test/java/aladdinsys/lifelong_learning_survey/domains/user/service/UserServiceTest.java
+++ b/src/test/java/aladdinsys/lifelong_learning_survey/domains/user/service/UserServiceTest.java
@@ -1,0 +1,73 @@
+package aladdinsys.lifelong_learning_survey.domains.user.service;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import aladdinsys.lifelong_learning_survey.domains.auth.dto.SignUpRequestDto;
+import aladdinsys.lifelong_learning_survey.domains.auth.service.AuthenticationService;
+import aladdinsys.lifelong_learning_survey.domains.user.constant.Role;
+import aladdinsys.lifelong_learning_survey.domains.user.dto.ResponseDto;
+import jakarta.persistence.EntityManager;
+
+@SpringBootTest
+@Transactional
+class UserServiceTest {
+
+	@Autowired
+	private UserService userService;
+	@Autowired
+	private AuthenticationService authService;
+	@Autowired
+	EntityManager em;
+
+	@BeforeEach
+	void setUp() {
+		authService.signUp(new SignUpRequestDto("testId", "testPassword", "홍길동", "12345", "hongildong@aladdinsys.co.kr"));
+		authService.signUp(new SignUpRequestDto("k2ngis", "testPassword2", "고경남", "12345", "k2ngis@aladdinsys.co.kr"));
+
+		em.clear();
+	}
+	@Test
+	@DisplayName("회원 정보 전체 조회")
+	void findAll() {
+		List<ResponseDto> result = userService.findAll();
+
+		assertThat(result.size()).isEqualTo(2);
+		assertThat(result.get(0).name()).isEqualTo("홍길동");
+		assertThat(result.get(1).name()).isEqualTo("고경남");
+	}
+
+	@Test
+	@DisplayName("회원 정보 By ID 조회")
+	void findById() {
+		ResponseDto result = userService.findById(1L);
+
+		assertThat(result.name()).isEqualTo("홍길동");
+		assertThat(result.email()).isEqualTo("hongildong@aladdinsys.co.kr");
+		assertThat(result.role()).isEqualTo(Role.USER);
+	}
+
+	@Test
+	void patch() {
+	}
+
+	@Test
+	void changePassword() {
+	}
+
+	@Test
+	void delete() {
+	}
+
+	@Test
+	void myInfo() {
+	}
+}

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -1,0 +1,29 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:aladdinsys-api;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;
+    driver-class-name: org.h2.Driver
+    username: aladdin
+    password:
+  jpa:
+    show-sql: false
+    hibernate:
+      ddl-auto: create-drop
+    database-platform: org.hibernate.dialect.H2Dialect
+    properties:
+      hibernate:
+        show_sql: false
+
+jwt:
+  access-token:
+    secret: +iBcUJRWGvl+94+ow4nXV1fzWIq4rph8x7MyRmrtWio=
+    expiration: 600000
+  refresh-token:
+    secret: gtzRlqF6bIkmOi5i15A9G5xbLdwiAMmZi6JPOeemC1E=
+    expiration: 86400000
+
+server:
+  servlet:
+    encoding:
+      charset: UTF-8
+      enabled: true
+      force: true


### PR DESCRIPTION
### Reviewer :  @jhjaladdinsys 

### 변경사항을 설명해주세요
#### 사용자 정보 API
- [x] 사용자의 MyInfo 조회 기능

- [x] 사용자 목록 조회
- [x] 사용자 단일 조회
- [x] 사용자 수정
- [x] 비밀번호 변경
- [x] 사용자 삭제

- [x] 테스트 코드 작성

### 특이사항을 설명해주세요
- 현재 스웨거나 RestDoc 은 적용하지 않음


### PR 올리기전에 체크 사항
- [x] 내가 작업한 코드에 대해서 단위 테스트 작성하고 통과 하였는가?
- [x] 코어 내용을 수정했을 경우 전체 프로젝트의 단위테스트를 통과 하였는가?
- [x] 다른 코드에 영향을 끼치지 않는가?
